### PR TITLE
Fixed issue with whitespace on edge browser

### DIFF
--- a/jquery.dropdown.css
+++ b/jquery.dropdown.css
@@ -66,6 +66,7 @@ select[data-dropdownjs][disabled] + .dropdownjs > input[readonly] {
   padding: 10px;
   overflow: auto;
   max-width: 500px;
+  max-height: 500px;
 }
 .dropdownjs > ul > li {
   cursor: pointer;


### PR DESCRIPTION
Added a max-height to dropdowns to prevent large lists from expanding below edge footer causing excess whitespace. Will be overridden with an inline style when activated. 